### PR TITLE
Minor improvement

### DIFF
--- a/average-voltage-calc.ino
+++ b/average-voltage-calc.ino
@@ -69,7 +69,7 @@ volSum+=apinVol;
 }
 
 
-avgVol=volSum/(6*loopNum);
+avgVol=volSum/(6.0*(double)loopNum);
 loopNum++;
 Serial.println("");
 delay(1000); //reading interval, change it for faster/slower data reading


### PR DESCRIPTION
Changed `6` (int) to `6.0` (double) in order to minimize the probability of integer typecasting.
Added `(double)` before `loopNum` to convert the integer to a double.